### PR TITLE
Rewrite PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,21 +1,21 @@
-pkgname='gobble'
+pkgname=gobble
 pkgver=1.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Window swallowing on any WM'
-arch=('x86_64')
 url='https://github.com/EmperorPenguin18/gobble/'
+source=("$pkgname-$pkgver.tar.gz::https://github.com/EmperorPenguin18/gobble/archive/refs/tags/$pkgver.tar.gz")
+arch=('x86_64')
 license=('GPL3')
+makedepends=('cargo')
 depends=('libxcb')
-makedepends=('rust')
+sha256sums=('a2fef6f612950cdc0595c39b7688bfb10300a10dfd4738d4e94ba979531dcc61')
 
 build () {
-  cd $startdir
-  make
-  mv target/release/gobble $srcdir/gobble
+  cd "$srcdir/$pkgname-$pkgver"
+  cargo build --release --target-dir target
 }
 
 package () {
-  install -Dm644 $startdir/LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-  mkdir -p "$pkgdir/usr/bin"
-  install -Dm755 $srcdir/gobble "$pkgdir/usr/bin/gobble"
+  cd "$srcdir/$pkgname-$pkgver"
+  install -Dm755 target/release/gobble -t "$pkgdir/usr/bin"
 }

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Arch
 ```
 git clone https://github.com/EmperorPenguin18/gobble
 cd gobble
-makepkg
-pacman -U gobble-* #as root
+makepkg -si
 ```
 
 Other Linux


### PR DESCRIPTION
There were many errors in the pkgbuild, rewrote to spec.

The pkgbuild should also have --locked specified on the build command
but as the tagged release has an out of date lockfile we can not.

I've ignored the makefile as it's just simpler to not use it