### PR TITLE
Upate dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+.gitignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
+name = "bitflags"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "gobble"
@@ -24,41 +24,32 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xcb"
-version = "0.10.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771e2b996df720cd1c6dd9ff90f62d91698fd3610cc078388d0564bdd6622a9c"
+checksum = "fb3acf6b0945550d37d3a683b8f7de9d9f66b2c14dc390313b34d7ac6f1b4089"
 dependencies = [
+ "bitflags",
  "libc",
- "log",
  "quick-xml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ repository = "https://github.com/EmperorPenguin18/gobble"
 license = "GPL3"
 
 [dependencies]
-xcb = ">=0.9"
-anyhow = ">=1.0.41"
+xcb = "1.0"
+anyhow = "1.0"
 
 [[bin]]
 name = "gobble"

--- a/gobble.rs
+++ b/gobble.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), anyhow::Error> {
     let mut flag_version = false;
     let mut flag_help = false;
     while args.len() > 1 {
-        if args[1].chars().nth(0).unwrap() == '-' {
+        if args[1].starts_with('-') {
             if args[1].chars().nth(1).unwrap() == 'o' {
                 flag_overlap = true;
             } else if args[1].chars().nth(1).unwrap() == 'v' {
@@ -29,99 +29,105 @@ fn main() -> Result<(), anyhow::Error> {
         args.remove(1);
     }
 
-    let exit_code = if flag_help == true {
+    let exit_code = if flag_help {
         println!("gobble - hide your current window while using an external program");
-        println!("");
+        println!();
         println!("USAGE:");
         println!("  gobble [OPTIONS] CMD ...");
-        println!("");
+        println!();
         println!("OPTIONS:");
-        println!("");
+        println!();
         println!("  -h      Displays the help message you're seeing now");
         println!("  -v      Displays the software version");
         println!("  -o      Uses overlap mode");
-        println!("");
+        println!();
         println!("See the manual for more information");
         0
-    } else if flag_version == true {
+    } else if flag_version {
         println!("gobble v1.2");
         println!("See https://github.com/EmperorPenguin18/gobble/releases for more info");
         0
-    } else if wayland == None {
-        // X11
-        let (conn, screen_num) = Connection::connect(None)?;
-        let win = conn
-            .wait_for_reply(conn.send_request(&x::GetInputFocus {}))?
-            .focus();
-        if flag_overlap == false {
-            // ensure child was spawned before we hide the window
-            let mut child: process::Child;
-            if args.len() > 1 {
-                child = command(&args)?;
-            } else {
-                process::exit(0);
-            }
-
-            conn.send_request_checked(&x::UnmapWindow { window: win });
-            let _ = conn.flush();
-
-            let exit_code = child.wait()?.code().unwrap_or(1);
-
-            conn.send_request_checked(&x::MapWindow { window: win });
-            let _ = conn.flush();
-            exit_code
-        } else {
-            let mut child: process::Child;
-            if args.len() > 1 {
-                child = command(&args)?;
-            } else {
-                process::exit(0);
-            }
-
-            let translate = conn.wait_for_reply(
-                conn.send_request(&x::TranslateCoordinates {
-                    src_window: win,
-                    dst_window: conn
-                        .get_setup()
-                        .roots()
-                        .nth(screen_num as usize)
-                        .unwrap()
-                        .root(),
-                    src_x: 0,
-                    src_y: 0,
-                }),
-            )?; //Translates relative position to absolute position
-            let geometry = conn.wait_for_reply(conn.send_request(&x::GetGeometry {
-                drawable: x::Drawable::Window(win),
-            }))?;
-            let values = [
-                x::ConfigWindow::X((translate.dst_x() as i32).into()).into(),
-                x::ConfigWindow::Y((translate.dst_y() as i32).into()).into(),
-                x::ConfigWindow::Width((geometry.width() as u16).into()).into(),
-                x::ConfigWindow::Height((geometry.height() as u16).into()).into(),
-            ];
-
-            let mut newwin = conn
-                .wait_for_reply(conn.send_request(&x::GetInputFocus {}))?
-                .focus();
-            while win == newwin {
-                newwin = conn
-                    .wait_for_reply(conn.send_request(&x::GetInputFocus {}))?
-                    .focus();
-            }
-            conn.send_request_checked(&x::ConfigureWindow {
-                window: newwin,
-                value_list: &values,
-            });
-
-            child.wait()?.code().unwrap_or(1)
-        }
+    } else if wayland.is_none() {
+        gobble_on_x11(flag_overlap, &args)?
     } else {
-        // Wayland
-        command(&args)?.wait()?.code().unwrap_or(1)
+        gobble_on_wayland(&args)?
     };
 
     process::exit(exit_code);
+}
+
+fn gobble_on_wayland(args: &[String]) -> Result<i32, anyhow::Error> {
+    Ok(command(args)?.wait()?.code().unwrap_or(1))
+}
+
+fn gobble_on_x11(flag_overlap: bool, args: &[String]) -> Result<i32, anyhow::Error> {
+    let (conn, screen_num) = Connection::connect(None)?;
+    let win = conn
+        .wait_for_reply(conn.send_request(&x::GetInputFocus {}))?
+        .focus();
+    Ok(if flag_overlap {
+        let mut child: process::Child;
+        if args.len() > 1 {
+            child = command(args)?;
+        } else {
+            process::exit(0);
+        }
+
+        let translate = conn.wait_for_reply(
+            conn.send_request(&x::TranslateCoordinates {
+                src_window: win,
+                dst_window: conn
+                    .get_setup()
+                    .roots()
+                    .nth(screen_num as usize)
+                    .unwrap()
+                    .root(),
+                src_x: 0,
+                src_y: 0,
+            }),
+        )?; //Translates relative position to absolute position
+        let geometry = conn.wait_for_reply(conn.send_request(&x::GetGeometry {
+            drawable: x::Drawable::Window(win),
+        }))?;
+        let values = [
+            x::ConfigWindow::X(i32::from(translate.dst_x())),
+            x::ConfigWindow::Y(i32::from(translate.dst_y())),
+            x::ConfigWindow::Width(geometry.width().into()),
+            x::ConfigWindow::Height(geometry.height().into()),
+        ];
+
+        let mut newwin = conn
+            .wait_for_reply(conn.send_request(&x::GetInputFocus {}))?
+            .focus();
+        while win == newwin {
+            newwin = conn
+                .wait_for_reply(conn.send_request(&x::GetInputFocus {}))?
+                .focus();
+        }
+        conn.send_request_checked(&x::ConfigureWindow {
+            window: newwin,
+            value_list: &values,
+        });
+
+        child.wait()?.code().unwrap_or(1)
+    } else {
+        // ensure child was spawned before we hide the window
+        let mut child: process::Child;
+        if args.len() > 1 {
+            child = command(args)?;
+        } else {
+            process::exit(0);
+        }
+
+        conn.send_request_checked(&x::UnmapWindow { window: win });
+        let _ = conn.flush();
+
+        let exit_code = child.wait()?.code().unwrap_or(1);
+
+        conn.send_request_checked(&x::MapWindow { window: win });
+        let _ = conn.flush();
+        exit_code
+    })
 }
 
 fn command(args: &[String]) -> Result<process::Child, anyhow::Error> {

--- a/gobble.rs
+++ b/gobble.rs
@@ -119,17 +119,18 @@ fn gobble_on_x11(flag_overlap: bool, args: &[String]) -> Result<i32, anyhow::Err
             process::exit(0);
         }
 
-        conn.send_request(&x::UnmapWindow {
+        let unmap_attempt = conn.send_request_checked(&x::UnmapWindow {
             window: parent_window,
         });
-        let _ = conn.flush();
+        conn.check_request(unmap_attempt)?;
 
         let exit_code = child.wait()?.code().unwrap_or(1);
 
-        conn.send_request(&x::MapWindow {
+        let map_attempt = conn.send_request_checked(&x::MapWindow {
             window: parent_window,
         });
-        let _ = conn.flush();
+        println!("Un-Gobbling.. Bye!");
+        conn.check_request(map_attempt)?;
 
         exit_code
     })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Fixes deprecation warning for using quick-xml 0.22.0

Changes proposed in this pull request:
- always use latest patch version of anyhow 1.0.x
- use stable version of xcb
